### PR TITLE
Update ring.py

### DIFF
--- a/ring.py
+++ b/ring.py
@@ -245,6 +245,8 @@ def fhemReadingsUpdate(dev,sleepForSec):
         time.sleep(sleepForSec)
 
 def downloadSnapshot(dev):
+    # don't let snapshot ever be undefined
+    snapshot = False
     try:
         snapshot = dev.get_snapshot()
         if snapshot:


### PR DESCRIPTION
Initialize snapshot to False in case the ring_doorbell lib hasn't been updated and get_snapshot fails without returning anything.